### PR TITLE
Updated release based on label

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -72,7 +72,7 @@ jobs:
               PATCH=0
             elif [[ "$label" == "bug" ]]; then
               PATCH=$((PATCH + 1))
-            elif [[ "$label" == "refactor" ]]; then
+            else
               echo "Refactor label detected. Skipping release process."
               echo "SKIP_RELEASE=true" >> $GITHUB_ENV
               exit 0


### PR DESCRIPTION
Now if there is an label that is not breaking, feature or bug, it will not create a release