### PR TITLE
Removed - 1 from elements.count when loading cheeps from the database

### DIFF
--- a/Chirp/src/SimpleDB/CsvDatabase.cs
+++ b/Chirp/src/SimpleDB/CsvDatabase.cs
@@ -34,7 +34,7 @@ namespace SimpleDB
             
             if (limit == null || limit > elements.Count())
             {
-                limit = elements.Count() - 1;
+                limit = elements.Count();
             }
 
             return elements.GetRange((int)(elements.Count() - limit), (int)limit);


### PR DESCRIPTION
This was done to set the limit to the size of all elements