### PR TITLE
Refactored Display method for cheep messages to make null argument display all cheeps

### DIFF
--- a/Chirp/src/Chirp.CLI.Client/Program.cs
+++ b/Chirp/src/Chirp.CLI.Client/Program.cs
@@ -21,10 +21,10 @@ Options:
 var db = CheepCsvDatabase.Instance;
 var arguments = new Docopt().Apply(usage, args, version: "1.0", exit: true)!;
 
-if (arguments["read"].IsTrue) 
+if (arguments["read"].IsTrue)
 {
     //DisplayCheeps(db, arguments["<limit>"].AsInt);
-    if (arguments["<limit>"].IsNullOrEmpty) WebDisplayCheeps(null);
+    if (arguments["<limit>"].IsNullOrEmpty) WebDisplayCheeps();
     else WebDisplayCheeps(arguments["<limit>"].AsInt);
 }
 else if (arguments["cheep"].IsTrue) 
@@ -61,7 +61,7 @@ void WebWriteCheep(string message)
     response.EnsureSuccessStatusCode();
 }
 
-void WebDisplayCheeps(int? limit)
+void WebDisplayCheeps(int? limit = null)
 {
     var baseUrl = "https://bdsa2024group10chirpremotedb-h3c8bne5cahweegw.northeurope-01.azurewebsites.net/";
     using HttpClient client = new();

--- a/Chirp/src/Chirp.CLI.Client/Program.cs
+++ b/Chirp/src/Chirp.CLI.Client/Program.cs
@@ -65,8 +65,12 @@ void WebDisplayCheeps(int? limit = null)
 {
     var baseUrl = "https://bdsa2024group10chirpremotedb-h3c8bne5cahweegw.northeurope-01.azurewebsites.net/";
     using HttpClient client = new();
-    client.BaseAddress = new Uri(baseUrl); 
+    client.BaseAddress = new Uri(baseUrl);
     var requestUri = $"/cheeps?limit={limit}";
+    
+    if (limit == null) requestUri = $"/cheeps";
+    else requestUri = $"/cheeps?limit={limit}";
+    
     var response = client.GetFromJsonAsync<Cheep[]>(requestUri).Result;
     if (response == null) throw new Exception("No response");
     UserInterface.PrintCheeps(response);


### PR DESCRIPTION
This refactoring makes 'null' argument in 'read' command line so a given '<limit>' isn't necessary. This is nice to see all sent messages so far.

This will need some other form of limit in the future ahead, so to not display all messages that has been sent in the database since the beginning