### PR TITLE
Fix workflow triggers

### DIFF
--- a/.github/workflows/Create_tag_on_merge _to_main.yml
+++ b/.github/workflows/Create_tag_on_merge _to_main.yml
@@ -80,6 +80,10 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "Calculated new version: $NEW_VERSION"
 
+      - name: Cancel Workflow
+        if: env.SKIP_RELEASE == 'true'
+        run: exit 78
+      
       # Create a new Git tag with the calculated version
       - name: Create Git Tag
         if: env.SKIP_RELEASE != 'true'

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -10,11 +10,15 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_run:
+      workflows: ['Create tag on PR Merge']
+      types: [completed]
   workflow_dispatch:
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
       # Checkout the code

--- a/.github/workflows/release_to_azure.yml
+++ b/.github/workflows/release_to_azure.yml
@@ -6,11 +6,15 @@ name: Build and deploy ASP.Net Core app to Azure Web App - bdsa2024group10chirpr
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ['Automatic release on tag creation']
+    types: [completed]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     defaults:
       run:


### PR DESCRIPTION
So the short version, GitHub sucks massive ass and is annoying as fuck.
The long one. GitHub doesn't want workflows to accidentally run forever, therefore when an action is done by a workflow, f.eks. creating a tag, it doesn't trigger the triggers of other workflows listening for that action. The proper way to do this is by having a separate GitHub amount or use your own, and create PAT and using that to do the actions so it seems like it's a user that does it. Unfortunately, I can't get that to work, so instead we are just going to use a trigger that checks for other workflows to complete.