### PR TITLE
FluentValidation for constraining the length of a cheep message

### DIFF
--- a/Chirp/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/Chirp/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -11,6 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentValidation" Version="11.10.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
     </ItemGroup>
 

--- a/Chirp/src/Chirp.Infrastructure/Model/Cheep.cs
+++ b/Chirp/src/Chirp.Infrastructure/Model/Cheep.cs
@@ -1,3 +1,5 @@
+using FluentValidation;
+
 namespace Chirp.Infrastructure.Model;
 
 public class Cheep
@@ -18,5 +20,13 @@ public class Cheep
         Message = message;
         TimeStamp = timeStamp;
         Author = author;
+    }
+
+    public class CheepValidator : AbstractValidator<Cheep>
+    {
+        public CheepValidator()
+        {
+            RuleFor(x => x.Message).MaximumLength(160);
+        }
     }
 }


### PR DESCRIPTION
This is mainly for future usage where cheeps can be stored outside of the UI.