### PR TITLE
Clean up private timeline

### DIFF
--- a/Chirp/src/Chirp.Web/Pages/Public.cshtml
+++ b/Chirp/src/Chirp.Web/Pages/Public.cshtml
@@ -13,20 +13,7 @@
     @if (Model.Cheeps.Any())
     {
         @await Component.InvokeAsync("PageButtons", new { pageNumber = Model.PageNumber, targetPage = "/", isLastPage = Model.Cheeps.Count < 32 })
-        <ul id="messagelist" class="cheeps">
-            @foreach (var cheep in Model.Cheeps)
-            {
-                <li>
-                    <p>
-                        <strong>
-                            <a href="/@cheep.Author">@cheep.Author</a>
-                        </strong>
-                        @cheep.Message
-                        <small>&mdash; @DateTimeOffset.FromUnixTimeSeconds(cheep.UnixTimestamp).DateTime.ToString("dd/MM/yy H:mm:ss")</small>
-                    </p>
-                </li>
-            }
-        </ul>
+        @await Component.InvokeAsync("CheepList", new {cheeps = Model.Cheeps})
     }
     else
     {

--- a/Chirp/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/Chirp/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,5 +1,5 @@
 ﻿using Chirp.Core;
-using Chirp.Web.Pages.Shared.Components.Timelines;
+using Chirp.Web.Pages.Shared;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Chirp.Web.Pages;

--- a/Chirp/src/Chirp.Web/Pages/Shared/Components/CheepList/Default.cshtml
+++ b/Chirp/src/Chirp.Web/Pages/Shared/Components/CheepList/Default.cshtml
@@ -1,0 +1,19 @@
+﻿@using Chirp.Core.DTO
+@{
+    IEnumerable<CheepDTO> cheeps = ViewBag.Cheeps;
+}
+
+<ul id="messagelist" class="cheeps">
+    @foreach (var cheep in cheeps)
+    {
+        <li>
+            <p>
+                <strong>
+                    <a href="/@cheep.Author">@cheep.Author</a>
+                </strong>
+                @cheep.Message
+                <small>&mdash; @DateTimeOffset.FromUnixTimeSeconds(cheep.UnixTimestamp).DateTime.ToString("dd/MM/yy H:mm:ss")</small>
+            </p>
+        </li>
+    }
+</ul>

--- a/Chirp/src/Chirp.Web/Pages/Shared/TimeLinePageModel.cs
+++ b/Chirp/src/Chirp.Web/Pages/Shared/TimeLinePageModel.cs
@@ -4,7 +4,7 @@ using Chirp.Web.Pages.BindingModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Chirp.Web.Pages.Shared.Components.Timelines;
+namespace Chirp.Web.Pages.Shared;
 
 public abstract class TimeLinePageModel(ICheepService service) : PageModel
 {

--- a/Chirp/src/Chirp.Web/Pages/Shared/TimeLinePageModel.cs
+++ b/Chirp/src/Chirp.Web/Pages/Shared/TimeLinePageModel.cs
@@ -12,7 +12,6 @@ public abstract class TimeLinePageModel(ICheepService service) : PageModel
     
     protected readonly ICheepService Service = service;
     
-    public string? Author { get; set; } 
     public int PageNumber = 1;
 
     [BindProperty] 
@@ -20,8 +19,6 @@ public abstract class TimeLinePageModel(ICheepService service) : PageModel
     
     public ActionResult OnPost(string? author, [FromQuery] int page)
     {
-        Author = author;
-        
         if (string.IsNullOrWhiteSpace(MessageModel.Message)) {
             ModelState.AddModelError("Message", "Message cannot be empty");
         }

--- a/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -13,7 +13,7 @@
 
     @if (Model.Cheeps.Any())
     {
-        @await Component.InvokeAsync("PageButtons", new { pageNumber = Model.PageNumber, targetPage = $"/{Model.Author}", isLastPage = Model.Cheeps.Count < 32 })
+        @await Component.InvokeAsync("PageButtons", new { pageNumber = Model.PageNumber, targetPage = $"/{routeName}", isLastPage = Model.Cheeps.Count < 32 })
         @await Component.InvokeAsync("CheepList", new {cheeps = Model.Cheeps})
     }
     else
@@ -21,6 +21,6 @@
         <em>There are no cheeps so far.</em>
     }
 
-    @await Component.InvokeAsync("PageButtons", new { pageNumber = Model.PageNumber, targetPage = $"/{Model.Author}", isLastPage = Model.Cheeps.Count < 32 })
+    @await Component.InvokeAsync("PageButtons", new { pageNumber = Model.PageNumber, targetPage = $"/{routeName}", isLastPage = Model.Cheeps.Count < 32 })
     
 </div>

--- a/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -14,20 +14,7 @@
     @if (Model.Cheeps.Any())
     {
         @await Component.InvokeAsync("PageButtons", new { pageNumber = Model.PageNumber, targetPage = $"/{Model.Author}", isLastPage = Model.Cheeps.Count < 32 })
-        <ul id="messagelist" class="cheeps">
-            @foreach (var cheep in Model.Cheeps)
-            {
-                <li>
-                    <p>
-                        <strong>
-                            <a href="/@cheep.Author">@cheep.Author</a>
-                        </strong>
-                        @cheep.Message
-                        <small>&mdash; @DateTimeOffset.FromUnixTimeSeconds(cheep.UnixTimestamp).DateTime.ToString("dd/MM/yy H:mm:ss")</small>
-                    </p>
-                </li>
-            }
-        </ul>
+        @await Component.InvokeAsync("CheepList", new {cheeps = Model.Cheeps})
     }
     else
     {

--- a/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -14,7 +14,6 @@ public class UserTimelineModel(ICheepService service) : TimeLinePageModel(servic
             return LocalRedirect(returnUrl);
         }
         
-        Author = author;
         PageNumber = page < 1 ? 1 : page;
         LoadCheeps(page);
         
@@ -23,11 +22,13 @@ public class UserTimelineModel(ICheepService service) : TimeLinePageModel(servic
 
     protected override void LoadCheeps(int page)
     {
-        if (Author == null)
+        var author = HttpContext.GetRouteValue("author")?.ToString();
+        
+        if (author == null)
         {
-            throw new ArgumentNullException(nameof(Author));
+            throw new ArgumentNullException(nameof(author), "Author cannot be null, failed to get the route value");
         }
 
-        Cheeps = Service.GetCheepsFromAuthorByPage(Author, page, 32);
+        Cheeps = Service.GetCheepsFromAuthorByPage(author, page, 32);
     }
 }

--- a/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/Chirp/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -1,5 +1,5 @@
 ﻿using Chirp.Core;
-using Chirp.Web.Pages.Shared.Components.Timelines;
+using Chirp.Web.Pages.Shared;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Chirp.Web.Pages;

--- a/Chirp/src/Chirp.Web/ViewComponents/CheepListViewComponent.cs
+++ b/Chirp/src/Chirp.Web/ViewComponents/CheepListViewComponent.cs
@@ -1,0 +1,13 @@
+﻿using Chirp.Core.DTO;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Chirp.Web.ViewComponents;
+
+public class CheepListViewComponent : ViewComponent
+{
+    public IViewComponentResult Invoke(IEnumerable<CheepDTO> cheeps)
+    {
+        ViewBag.Cheeps = cheeps;
+        return View("Default");
+    }
+}


### PR DESCRIPTION
Instead of having a property for the name of the author we set when the endpoint is called, I have changed it to get the author name via the route value from the http context.
It's only the 2 recent commits, the others is because it's building upon #294 